### PR TITLE
Add `empty` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Usage: `plushu config:unset <app> <key>...`
 
 Unsets keys in an app's config.
 
+## config:empty
+
+Usage: `plushu config:empty <app>`
+
+Unsets *all* keys in an app's config, reverting it to its initial empty and
+unconfigured state.
+
 ## config:get
 
 Usage: `plushu config:get <app> <key>`

--- a/subcommands/empty
+++ b/subcommands/empty
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+if [[ -z "$2" ]]; then
+  echo "Missing app name" >&2
+  exit 1
+else
+  app=$2
+  app_dir=$PLUSHU_ROOT/apps/$app
+  env_file=$app_dir/config.env
+
+  # Check if app exists with the same name
+  if [ ! -d "$app_dir" ]; then
+    echo "App $app does not exist" >&2
+    exit 1
+  fi
+
+  if [ ! -f "$env_file" ]; then
+    touch "$env_file"
+  fi
+fi
+
+# If a third argument was provided
+if [[ -n "$3" ]]; then
+  # Panic
+  echo "empty: too many arguments (did you mean to use unset?)" >&2
+  exit 1
+else
+  # Empty the config file
+  > "$env_file"
+fi
+
+# If there is a build image to base a release on
+if [[ -f "$app_dir/build.iid" ]]; then
+  # Restart app with new configuration
+  $PLUSHU_ROOT/lib/runhook release "$app"
+  $PLUSHU_ROOT/lib/runhook deploy "$app"
+fi


### PR DESCRIPTION
I'm not sure whether or not this command should be added to the `config` plugin.

I picked the most clearly-not-a-synonym-for-`unset` name I could (short of something outrageous like `nuke`) and I added a safety check so that it will fail in the event that somebody _does_ mistake it for `unset`.
## The case against

As `empty` is more closely associated with the adjective "empty" than the verb "empty", this could be misconstrued as a condition test command ("is the config empty?"). Since `plushu` in general doesn't _have_ any commands like that (and you could obviously test that with `[[ -z $(plushu config $app)]]`), it would be weird for someone to think that, but it's a plausible mistake that a curious cat could stumble into (once).

Ambiguity aside, it's a footgun for an uncommon task that could otherwise be accomplished with the one-liner:

``` bash
plushu config $app | sed 's/=.*//g' | xargs plushu config:unset $app
```
## The case for

The rationale being that the one-liner is a complex command requiring two network round-trips and a `sed` pipe step (not including all the server churn), for something that can be blindly accomplished with _one character_ on the server. (And it's not _that_ outrageous to consider the possibility that someone might require all-new config variables and the old config could cause problems- think of [envigor](https://github.com/stuartpb/envigor) in the case of multiple service providers being defined.)
